### PR TITLE
Extract shared JS into presc.js, add .nojekyll, clean up all pages

### DIFF
--- a/weight/chart.html
+++ b/weight/chart.html
@@ -22,140 +22,21 @@
     <div id="chart-container" class="result-box">
       <canvas id="weightChart"></canvas>
     </div>
+
+    <a href="./index.html" class="note-text" style="display: block; color: #5fd3b9; text-decoration: none; margin-top: 16px;">→ Go to Calculator</a>
+    <a href="./setup.html" class="note-text" style="display: block; color: #5fd3b9; text-decoration: none; margin-top: 8px;">→ Update Starting Weight</a>
   </main>
   <script src="./firebase-config.js"></script>
   <script type="module">
-    import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.22.0/firebase-app.js';
-    import { getFirestore, collection, getDocs, query, orderBy } from 'https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore.js';
-    const firebaseConfig = window.firebaseConfig;
-    if (!firebaseConfig || !firebaseConfig.projectId) {
-      throw new Error('Firebase config not loaded. Ensure firebase-config.js is present.');
+    import { loadWeightData, renderChart } from './presc.js';
+
+    const container = document.getElementById('chart-container');
+    const data = await loadWeightData();   // no currentUser → percentages only (privacy)
+    if (data.length) {
+      renderChart('weightChart', data, container);
+    } else {
+      container.innerHTML = '<p class="note-text">No weight data recorded yet.</p>';
     }
-    const app = initializeApp(firebaseConfig);
-    const db = getFirestore(app);
-    const USERS = ['Sarah', 'Jay'];
-    const CHART_COLORS = { Sarah: '#ff69b4', Jay: '#2196f3' };
-    function getMonday(date) {
-      const d = new Date(date);
-      const day = d.getDay();
-      const diff = d.getDate() - day + (day === 0 ? -6 : 1);
-      return new Date(d.setDate(diff));
-    }
-    function getWeekKey(date) {
-      const monday = getMonday(date);
-      return monday.toISOString().slice(0, 10);
-    }
-    function getWeeklyWinnersAndMissing(data) {
-      const weeks = {};
-      data.forEach(entry => {
-        const week = getWeekKey(entry.date);
-        if (!weeks[week]) weeks[week] = {};
-        const entryDate = new Date(entry.date);
-        const monday = getMonday(entry.date);
-        if (entryDate >= monday && entryDate < new Date(monday.getTime() + 7 * 86400000)) {
-          weeks[week][entry.user] = entry;
-        }
-      });
-      const results = {};
-      Object.entries(weeks).forEach(([week, users]) => {
-        let winner = null;
-        let missing = [];
-        if (users.Jay && users.Sarah) {
-          winner = users.Jay.changePct < users.Sarah.changePct ? 'Jay' : 'Sarah';
-        } else {
-          if (!users.Jay) missing.push('Jay');
-          if (!users.Sarah) missing.push('Sarah');
-        }
-        results[week] = { winner, missing };
-      });
-      return results;
-    }
-    function plotChart(data) {
-      const ctx = document.getElementById('weightChart').getContext('2d');
-      const dateKeys = Array.from(new Set(data.map((entry) => entry.date.slice(0, 10))));
-      dateKeys.sort();
-      const labels = dateKeys.map((date) => new Date(date).toLocaleDateString());
-      const datasets = USERS.map((user) => {
-        const userEntries = data.filter((entry) => entry.user === user).sort((a, b) => new Date(a.date) - new Date(b.date));
-        const valuesByDate = userEntries.reduce((acc, entry) => {
-          const dateKey = entry.date.slice(0, 10);
-          acc[dateKey] = Math.round((100 + entry.changePct) * 10) / 10;
-          return acc;
-        }, {});
-        const userData = dateKeys.map((dateKey) => valuesByDate[dateKey] ?? null);
-        return {
-          label: user,
-          data: userData,
-          borderColor: CHART_COLORS[user],
-          backgroundColor: user === 'Sarah' ? 'rgba(255,105,180,0.15)' : 'rgba(33,150,243,0.15)',
-          tension: 0.35,
-          fill: false,
-          pointRadius: 4,
-          pointHoverRadius: 6
-        };
-      });
-      // Show weekly winner and missing entry messages above chart
-      const results = getWeeklyWinnersAndMissing(data);
-      let winnerHtml = '<div class="note-text" style="margin-bottom:10px;">';
-      Object.entries(results).forEach(([week, {winner, missing}]) => {
-        if (winner) {
-          winnerHtml += `<b>Week of ${week}:</b> Winner: <span style=\"color:${CHART_COLORS[winner]}\">${winner}</span><br/>`;
-        } else if (missing.length > 0) {
-          winnerHtml += `<b>Week of ${week}:</b> <span style=\"color:#ffb300\">${missing.join(' and ')} ha${missing.length > 1 ? 've' : 's'} not entered their weight this week</span><br/>`;
-        }
-      });
-      winnerHtml += '</div>';
-      let chartContainer = document.getElementById('chart-container');
-      chartContainer.insertAdjacentHTML('afterbegin', winnerHtml);
-      if (window.weightChart) {
-        window.weightChart.destroy();
-      }
-      window.weightChart = new Chart(ctx, {
-        type: 'line',
-        data: { labels: labels, datasets: datasets },
-        options: {
-          responsive: true,
-          plugins: {
-            legend: { position: 'top' },
-            tooltip: {
-              callbacks: {
-                label: (context) => `${context.dataset.label}: ${context.parsed.y}%`
-              }
-            }
-          },
-          scales: {
-            x: { title: { display: true, text: 'Date' } },
-            y: {
-              beginAtZero: false,
-              suggestedMin: 80,
-              suggestedMax: 110,
-              title: { display: true, text: 'Relative Weight (%)' },
-              ticks: { callback: (value) => `${value}%` }
-            }
-          }
-        }
-      });
-    }
-    async function loadAllWeightData() {
-      try {
-        const q = query(collection(db, 'weightData'), orderBy('date'));
-        const querySnapshot = await getDocs(q);
-        const allData = [];
-        querySnapshot.forEach((doc) => {
-          allData.push(doc.data());
-        });
-        return allData;
-      } catch (error) {
-        console.error('Error loading chart data:', error);
-        return [];
-      }
-    }
-    (async () => {
-      const data = await loadAllWeightData();
-      if (data.length > 0) {
-        plotChart(data);
-      }
-    })();
   </script>
 </body>
 </html>

--- a/weight/index.html
+++ b/weight/index.html
@@ -2,12 +2,9 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="../main.css" />
   <link rel="stylesheet" href="./weightcalc.css" />
-  <script type="module">
-    window.firebaseImports = {};
-  </script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <title>PRESC Weight Change Calculator</title>
 </head>
@@ -47,6 +44,7 @@
     </div>
 
     <a href="./setup.html" class="note-text" style="display: block; color: #5fd3b9; text-decoration: none; margin-bottom: 16px;">→ Update Starting Weight</a>
+    <a href="./chart.html" class="note-text" style="display: block; color: #5fd3b9; text-decoration: none; margin-bottom: 16px;">→ View Competition Chart</a>
 
     <section class="input-grid">
 
@@ -91,340 +89,69 @@
 
   <script src="./firebase-config.js"></script>
   <script type="module">
-    import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.22.0/firebase-app.js';
-    import { getFirestore, collection, addDoc, getDocs, query, where, orderBy } from 'https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore.js';
+    import {
+      db, loadStartingWeight, loadWeightData, saveWeight,
+      renderChart, parseWeightInputs, todayISO
+    } from './presc.js';
 
-    // Firebase configuration - loaded from generated config file
-    const firebaseConfig = window.firebaseConfig;
-    if (!firebaseConfig || !firebaseConfig.projectId) {
-      throw new Error('Firebase config not loaded. Ensure firebase-config.js is present.');
-    }
+    const weightUnit       = document.getElementById('weight-unit');
+    const userSelect       = document.getElementById('user-select');
+    const measurementDate  = document.getElementById('measurement-date');
+    const resultContainer  = document.getElementById('result');
+    const resultText       = document.getElementById('result-text');
+    const chartContainer   = document.getElementById('chart-container');
+    let startingWeightKg   = null;
 
-    // Initialize Firebase
-    const app = initializeApp(firebaseConfig);
-    const db = getFirestore(app);
-
-    async function saveWeightData(user, startKg, todayKg, changePct, date) {
-      try {
-        await addDoc(collection(db, 'weightData'), {
-          user: user,
-          date: date,
-          startWeight: startKg,
-          todayWeight: todayKg,
-          changePct: changePct
-        });
-      } catch (error) {
-        console.error('Error saving data:', error);
-      }
-    }
-
-
-    // Only return actual weights for the current user, and only percentage change for the other
-    async function loadWeightDataForPrivacy(currentUser) {
-      try {
-        const q = query(collection(db, 'weightData'), orderBy('date'));
-        const querySnapshot = await getDocs(q);
-        const data = [];
-        querySnapshot.forEach((doc) => {
-          const d = doc.data();
-          if (d.user === currentUser) {
-            data.push(d);
-          } else {
-            // Hide actual weights for the other user
-            data.push({
-              user: d.user,
-              date: d.date,
-              changePct: d.changePct
-            });
-          }
-        });
-        return data;
-      } catch (error) {
-        console.error('Error loading data:', error);
-        return [];
-      }
-    }
-
-    let weightChart = null;
-    const USERS = ['Sarah', 'Jay'];
-    // Sarah = pink, Jay = blue
-    const CHART_COLORS = {
-      Sarah: '#ff69b4', // pink
-      Jay: '#2196f3'    // blue
-    };
-
-    function plotChart(data) {
-      const ctx = document.getElementById('weightChart').getContext('2d');
-      const dateKeys = Array.from(new Set(data.map((entry) => entry.date.slice(0, 10))));
-      dateKeys.sort();
-      const labels = dateKeys.map((date) => new Date(date).toLocaleDateString());
-
-      const datasets = USERS.map((user) => {
-        const userEntries = data
-          .filter((entry) => entry.user === user)
-          .sort((a, b) => new Date(a.date) - new Date(b.date));
-
-        const valuesByDate = userEntries.reduce((acc, entry) => {
-          const dateKey = entry.date.slice(0, 10);
-          acc[dateKey] = Math.round((100 + entry.changePct) * 10) / 10;
-          return acc;
-        function getMonday(date) {
-          const d = new Date(date);
-          const day = d.getDay();
-          const diff = d.getDate() - day + (day === 0 ? -6 : 1); // adjust when day is sunday
-          return new Date(d.setDate(diff));
-        }
-
-        function getWeekKey(date) {
-          const monday = getMonday(date);
-          return monday.toISOString().slice(0, 10);
-        }
-
-        function getWeeklyWinnersAndMissing(data) {
-          // Group by week, only consider entries on or after Monday of each week
-          const weeks = {};
-          data.forEach(entry => {
-            const week = getWeekKey(entry.date);
-            if (!weeks[week]) weeks[week] = {};
-            // Only count entries for the Monday of the week
-            const entryDate = new Date(entry.date);
-            const monday = getMonday(entry.date);
-            // Accept entries from Monday to Sunday of that week
-            if (entryDate >= monday && entryDate < new Date(monday.getTime() + 7 * 86400000)) {
-              weeks[week][entry.user] = entry;
-            }
-          });
-          // For each week, determine winner and missing
-          const results = {};
-          Object.entries(weeks).forEach(([week, users]) => {
-            let winner = null;
-            let missing = [];
-            if (users.Jay && users.Sarah) {
-              winner = users.Jay.changePct < users.Sarah.changePct ? 'Jay' : 'Sarah';
-            } else {
-              if (!users.Jay) missing.push('Jay');
-              if (!users.Sarah) missing.push('Sarah');
-            }
-            results[week] = { winner, missing };
-          });
-          return results;
-        }
-
-        function plotChart(data) {
-          const ctx = document.getElementById('weightChart').getContext('2d');
-          const dateKeys = Array.from(new Set(data.map((entry) => entry.date.slice(0, 10))));
-          dateKeys.sort();
-          const labels = dateKeys.map((date) => new Date(date).toLocaleDateString());
-
-          const datasets = USERS.map((user) => {
-            const userEntries = data
-              .filter((entry) => entry.user === user)
-              .sort((a, b) => new Date(a.date) - new Date(b.date));
-
-            const valuesByDate = userEntries.reduce((acc, entry) => {
-              const dateKey = entry.date.slice(0, 10);
-              acc[dateKey] = Math.round((100 + entry.changePct) * 10) / 10;
-              return acc;
-            }, {});
-
-            const userData = dateKeys.map((dateKey) => valuesByDate[dateKey] ?? null);
-
-            return {
-              label: user,
-              data: userData,
-              borderColor: CHART_COLORS[user],
-              backgroundColor: user === 'Sarah' ? 'rgba(255,105,180,0.15)' : 'rgba(33,150,243,0.15)',
-              tension: 0.35,
-              fill: false,
-              pointRadius: 4,
-              pointHoverRadius: 6
-            };
-          });
-
-          // Show weekly winner and missing entry messages above chart
-          const results = getWeeklyWinnersAndMissing(data);
-          let winnerHtml = '<div class="note-text" style="margin-bottom:10px;">';
-          Object.entries(results).forEach(([week, {winner, missing}]) => {
-            if (winner) {
-              winnerHtml += `<b>Week of ${week}:</b> Winner: <span style=\"color:${CHART_COLORS[winner]}\">${winner}</span><br/>`;
-            } else if (missing.length > 0) {
-              winnerHtml += `<b>Week of ${week}:</b> <span style=\"color:#ffb300\">${missing.join(' and ')} ha${missing.length > 1 ? 've' : 's'} not entered their weight this week</span><br/>`;
-            }
-          });
-          winnerHtml += '</div>';
-          let chartContainer = document.getElementById('chart-container');
-          chartContainer.insertAdjacentHTML('afterbegin', winnerHtml);
-
-          if (weightChart) {
-            weightChart.destroy();
-          }
-
-          weightChart = new Chart(ctx, {
-            type: 'line',
-            data: { labels: labels, datasets: datasets },
-            options: {
-              responsive: true,
-              plugins: {
-                legend: {
-                  position: 'top'
-                },
-                tooltip: {
-                  callbacks: {
-                    label: (context) => `${context.dataset.label}: ${context.parsed.y}%`
-                  }
-                }
-              },
-              scales: {
-                x: {
-                  title: {
-                    display: true,
-                    text: 'Date'
-                  }
-                },
-                y: {
-                  beginAtZero: false,
-                  suggestedMin: 80,
-                  suggestedMax: 110,
-                  title: {
-                    display: true,
-                    text: 'Relative Weight (%)'
-                  },
-                  ticks: {
-                    callback: (value) => `${value}%`
-                  }
-                }
-              }
-            }
-          });
-        }
-        return [];
-      }
-    }
-
-    async function loadStartingWeight(user) {
-      try {
-        const q = query(collection(db, 'startingWeight'), where('user', '==', user));
-        const querySnapshot = await getDocs(q);
-        if (!querySnapshot.empty) {
-          const doc = querySnapshot.docs[0];
-          return doc.data().weight;
-        } else {
-          return null;
-        }
-      } catch (error) {
-        console.error('Error loading starting weight:', error);
-        return null;
-      }
-    }
-
-    const weightUnit = document.getElementById('weight-unit');
-    const userSelect = document.getElementById('user-select');
-    const measurementDate = document.getElementById('measurement-date');
-    let startingWeightKg = null;
-
-    // Set date input to today
-    function setDateToToday() {
-      const today = new Date();
-      const year = today.getFullYear();
-      const month = String(today.getMonth() + 1).padStart(2, '0');
-      const day = String(today.getDate()).padStart(2, '0');
-      measurementDate.value = `${year}-${month}-${day}`;
-    }
-
-    setDateToToday();
+    measurementDate.value = todayISO();
 
     userSelect.addEventListener('change', async () => {
       startingWeightKg = await loadStartingWeight(userSelect.value);
     });
 
-    // Load starting weight on page load
-    (async () => {
-      startingWeightKg = await loadStartingWeight(userSelect.value);
-    })();
+    /* ── Unit‑field toggling ─────────────────────────── */
 
     function toggleUnitFields(unit) {
-      const stlb = document.getElementById('today-stlb');
-      const lb = document.getElementById('today-lb');
-      const kg = document.getElementById('today-kg');
-
-      stlb.hidden = unit !== 'st-lb';
-      lb.hidden = unit !== 'lb';
-      kg.hidden = unit !== 'kg';
+      document.getElementById('today-stlb').hidden = unit !== 'st-lb';
+      document.getElementById('today-lb').hidden   = unit !== 'lb';
+      document.getElementById('today-kg').hidden   = unit !== 'kg';
     }
 
     function clearHiddenFields(unit) {
-      if (unit !== 'st-lb') {
-        document.getElementById('today-stones').value = '';
-        document.getElementById('today-pounds').value = '';
-      }
-      if (unit !== 'lb') {
-        document.getElementById('today-pounds-only').value = '';
-      }
-      if (unit !== 'kg') {
-        document.getElementById('today-kilograms').value = '';
-      }
+      if (unit !== 'st-lb') { document.getElementById('today-stones').value = ''; document.getElementById('today-pounds').value = ''; }
+      if (unit !== 'lb')    { document.getElementById('today-pounds-only').value = ''; }
+      if (unit !== 'kg')    { document.getElementById('today-kilograms').value = ''; }
     }
 
     toggleUnitFields(weightUnit.value || 'st-lb');
     weightUnit.addEventListener('change', () => {
-      if (weightUnit.value) {
-        clearHiddenFields(weightUnit.value);
-        toggleUnitFields(weightUnit.value);
-      }
+      clearHiddenFields(weightUnit.value);
+      toggleUnitFields(weightUnit.value);
     });
 
-    function parseWeight() {
-      const unit = weightUnit.value;
-      if (unit === 'st-lb') {
-        const stones = parseFloat(document.getElementById('today-stones').value) || 0;
-        const pounds = parseFloat(document.getElementById('today-pounds').value) || 0;
-        return stones * 6.35029 + pounds * 0.45359237;
-      }
-      if (unit === 'lb') {
-        return (parseFloat(document.getElementById('today-pounds-only').value) || 0) * 0.45359237;
-      }
-      return parseFloat(document.getElementById('today-kilograms').value) || 0;
+    /* ── Calculate button ────────────────────────────── */
+
+    function showError(msg) {
+      resultContainer.hidden = false;
+      resultText.textContent = msg;
+      resultText.className = 'result-value';
+      chartContainer.hidden = true;
     }
 
     document.getElementById('calculate-btn').addEventListener('click', async () => {
       const user = userSelect.value;
-      const unit = weightUnit.value;
-      const resultContainer = document.getElementById('result');
-      const resultText = document.getElementById('result-text');
-      const chartContainer = document.getElementById('chart-container');
-
-      if (!user) {
-        resultContainer.hidden = false;
-        resultText.textContent = 'Please select a user.';
-        resultText.className = 'result-value';
-        chartContainer.hidden = true;
-        return;
-      }
-
-      if (!unit) {
-        resultContainer.hidden = false;
-        resultText.textContent = 'Please select input units.';
-        resultText.className = 'result-value';
-        chartContainer.hidden = true;
-        return;
-      }
+      if (!user)  return showError('Please select a user.');
+      if (!weightUnit.value) return showError('Please select input units.');
 
       if (!startingWeightKg || startingWeightKg <= 0) {
-        resultContainer.hidden = false;
-        resultText.textContent = 'No starting weight set. Go to Setup first.';
-        resultText.className = 'result-value';
-        chartContainer.hidden = true;
-        return;
+        startingWeightKg = await loadStartingWeight(user);
       }
+      if (!startingWeightKg || startingWeightKg <= 0) return showError('No starting weight set. Go to Setup first.');
 
-      const todayKg = parseWeight();
-      if (!todayKg || todayKg <= 0) {
-        resultContainer.hidden = false;
-        resultText.textContent = 'Enter a valid current weight.';
-        resultText.className = 'result-value';
-        chartContainer.hidden = true;
-        return;
-      }
+      const todayKg = parseWeightInputs(weightUnit.value, {
+        stones: 'today-stones', pounds: 'today-pounds',
+        poundsOnly: 'today-pounds-only', kg: 'today-kilograms'
+      });
+      if (!todayKg || todayKg <= 0) return showError('Enter a valid current weight.');
 
       const changePct = ((todayKg - startingWeightKg) / startingWeightKg) * 100;
       const formatted = Math.abs(changePct).toFixed(1);
@@ -435,14 +162,14 @@
       resultText.className = `result-value ${isLoss ? 'lost' : 'gained'}`;
       resultContainer.hidden = false;
 
-      // Save data with measurement date
-      const selectedDate = measurementDate.value ? new Date(measurementDate.value).toISOString() : new Date().toISOString();
-      await saveWeightData(user, startingWeightKg, todayKg, changePct, selectedDate);
+      const selectedDate = measurementDate.value
+        ? new Date(measurementDate.value).toISOString()
+        : new Date().toISOString();
+      await saveWeight(user, startingWeightKg, todayKg, changePct, selectedDate);
 
-      // Load and plot both users on the chart, but only show actual weights for current user
-      const data = await loadWeightDataForPrivacy(user);
-      if (data.length > 0) {
-        plotChart(data);
+      const data = await loadWeightData(user);
+      if (data.length) {
+        renderChart('weightChart', data, chartContainer);
         chartContainer.hidden = false;
       } else {
         chartContainer.hidden = true;

--- a/weight/presc.js
+++ b/weight/presc.js
@@ -1,0 +1,204 @@
+/**
+ * PRESC Weight Competition — shared utilities
+ * Used by index.html, chart.html, and setup.html
+ */
+
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.22.0/firebase-app.js';
+import {
+  getFirestore, collection, addDoc, getDocs, deleteDoc,
+  query, where, orderBy
+} from 'https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore.js';
+
+/* ── Firebase bootstrap ─────────────────────────────── */
+
+const firebaseConfig = window.firebaseConfig;
+if (!firebaseConfig || !firebaseConfig.projectId) {
+  document.body.innerHTML =
+    '<p style="color:#ff7b7b;text-align:center;margin-top:40vh">' +
+    'Firebase config could not be loaded.<br>Please try refreshing the page.' +
+    '</p>';
+  throw new Error('firebase-config.js missing or empty');
+}
+
+const app = initializeApp(firebaseConfig);
+export const db = getFirestore(app);
+
+/* ── Constants ──────────────────────────────────────── */
+
+export const USERS   = ['Jay', 'Sarah'];
+export const COLORS  = { Jay: '#2196f3', Sarah: '#ff69b4' };
+const MS_PER_WEEK    = 7 * 86_400_000;
+
+/* ── Date helpers (Monday = weigh day) ──────────────── */
+
+export function getMonday(date) {
+  const d = new Date(date);
+  const day = d.getDay();                       // 0 = Sun … 6 = Sat
+  d.setDate(d.getDate() - day + (day === 0 ? -6 : 1));
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+export function weekKey(date) {
+  return getMonday(date).toISOString().slice(0, 10);
+}
+
+/* ── Firestore helpers ──────────────────────────────── */
+
+export async function saveWeight(user, startKg, todayKg, changePct, date) {
+  await addDoc(collection(db, 'weightData'), {
+    user, date, startWeight: startKg, todayWeight: todayKg, changePct
+  });
+}
+
+export async function loadStartingWeight(user) {
+  if (!user) return null;
+  const snap = await getDocs(
+    query(collection(db, 'startingWeight'), where('user', '==', user))
+  );
+  return snap.empty ? null : snap.docs[0].data().weight;
+}
+
+export async function saveStartingWeight(user, weightKg, unit) {
+  // Remove previous entry
+  const snap = await getDocs(
+    query(collection(db, 'startingWeight'), where('user', '==', user))
+  );
+  for (const doc of snap.docs) await deleteDoc(doc.ref);
+
+  await addDoc(collection(db, 'startingWeight'), {
+    user, weight: weightKg, unit, date: new Date().toISOString()
+  });
+}
+
+/**
+ * Load weight data with privacy: only the currentUser sees actual weights.
+ * If currentUser is null (chart page), only percentages are returned.
+ */
+export async function loadWeightData(currentUser = null) {
+  const snap = await getDocs(
+    query(collection(db, 'weightData'), orderBy('date'))
+  );
+  return snap.docs.map(doc => {
+    const d = doc.data();
+    if (currentUser && d.user === currentUser) return d;
+    return { user: d.user, date: d.date, changePct: d.changePct };
+  });
+}
+
+/* ── Weekly competition logic ───────────────────────── */
+
+export function weeklyResults(data) {
+  const weeks = {};
+
+  data.forEach(entry => {
+    const wk  = weekKey(entry.date);
+    const mon = getMonday(entry.date);
+    const d   = new Date(entry.date);
+    if (d >= mon && d < new Date(mon.getTime() + MS_PER_WEEK)) {
+      if (!weeks[wk]) weeks[wk] = {};
+      weeks[wk][entry.user] = entry;
+    }
+  });
+
+  return Object.entries(weeks).map(([wk, users]) => {
+    const missing = USERS.filter(u => !users[u]);
+    let winner = null;
+    if (missing.length === 0) {
+      winner = users.Jay.changePct < users.Sarah.changePct ? 'Jay' : 'Sarah';
+    }
+    return { week: wk, winner, missing };
+  });
+}
+
+/* ── Chart rendering ────────────────────────────────── */
+
+let chartInstance = null;
+
+export function renderChart(canvasId, data, containerEl) {
+  const ctx = document.getElementById(canvasId).getContext('2d');
+
+  // Unique sorted dates
+  const dateKeys = [...new Set(data.map(e => e.date.slice(0, 10)))].sort();
+  const labels   = dateKeys.map(d => new Date(d).toLocaleDateString());
+
+  const datasets = USERS.map(user => {
+    const byDate = {};
+    data.filter(e => e.user === user)
+        .sort((a, b) => new Date(a.date) - new Date(b.date))
+        .forEach(e => { byDate[e.date.slice(0, 10)] = Math.round((100 + e.changePct) * 10) / 10; });
+
+    return {
+      label: user,
+      data: dateKeys.map(dk => byDate[dk] ?? null),
+      borderColor: COLORS[user],
+      backgroundColor: user === 'Sarah' ? 'rgba(255,105,180,0.15)' : 'rgba(33,150,243,0.15)',
+      tension: 0.35, fill: false, pointRadius: 4, pointHoverRadius: 6
+    };
+  });
+
+  // Weekly summary HTML
+  const results = weeklyResults(data);
+  containerEl.querySelectorAll('.weekly-summary').forEach(el => el.remove());
+
+  if (results.length) {
+    const html = results.map(({ week, winner, missing }) => {
+      if (winner) {
+        return `<b>Week of ${week}:</b> Winner: <span style="color:${COLORS[winner]}">${winner}</span>`;
+      }
+      const names = missing.join(' and ');
+      return `<b>Week of ${week}:</b> <span style="color:#ffb300">${names} ha${missing.length > 1 ? 've' : 's'} not entered their weight this week</span>`;
+    }).join('<br/>');
+
+    containerEl.insertAdjacentHTML(
+      'afterbegin',
+      `<div class="weekly-summary note-text" style="margin-bottom:10px">${html}</div>`
+    );
+  }
+
+  if (chartInstance) chartInstance.destroy();
+
+  chartInstance = new Chart(ctx, {
+    type: 'line',
+    data: { labels, datasets },
+    options: {
+      responsive: true,
+      plugins: {
+        legend: { position: 'top' },
+        tooltip: { callbacks: { label: c => `${c.dataset.label}: ${c.parsed.y}%` } }
+      },
+      scales: {
+        x: { title: { display: true, text: 'Week' } },
+        y: {
+          beginAtZero: false, suggestedMin: 90, suggestedMax: 105,
+          title: { display: true, text: 'Relative Weight (%)' },
+          ticks: { callback: v => `${v}%` }
+        }
+      }
+    }
+  });
+}
+
+/* ── Unit conversion ────────────────────────────────── */
+
+const ST_TO_KG = 6.35029;
+const LB_TO_KG = 0.45359237;
+
+export function parseWeightInputs(unit, ids) {
+  if (unit === 'st-lb') {
+    const st = parseFloat(document.getElementById(ids.stones).value) || 0;
+    const lb = parseFloat(document.getElementById(ids.pounds).value) || 0;
+    return st * ST_TO_KG + lb * LB_TO_KG;
+  }
+  if (unit === 'lb') {
+    return (parseFloat(document.getElementById(ids.poundsOnly).value) || 0) * LB_TO_KG;
+  }
+  return parseFloat(document.getElementById(ids.kg).value) || 0;
+}
+
+/* ── Today's date string (YYYY-MM-DD) ───────────────── */
+
+export function todayISO() {
+  const t = new Date();
+  return `${t.getFullYear()}-${String(t.getMonth() + 1).padStart(2, '0')}-${String(t.getDate()).padStart(2, '0')}`;
+}

--- a/weight/setup.html
+++ b/weight/setup.html
@@ -66,7 +66,8 @@
     </section>
 
     <button class="calculate-button" id="save-btn" type="button">Save Starting Weight</button>
-    <a href="./index.html" class="calculate-button" style="text-decoration: none; display: block; text-align: center; margin-top: 12px;">Go to Calculator</a>
+    <a href="./index.html" class="note-text" style="display: block; color: #5fd3b9; text-decoration: none; margin-top: 12px;">→ Go to Calculator</a>
+    <a href="./chart.html" class="note-text" style="display: block; color: #5fd3b9; text-decoration: none; margin-top: 8px;">→ View Competition Chart</a>
 
     <div id="result" class="result-box" hidden>
       <p id="result-text" class="result-value"></p>
@@ -75,111 +76,48 @@
 
   <script src="./firebase-config.js"></script>
   <script type="module">
-    import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.22.0/firebase-app.js';
-    import { getFirestore, collection, addDoc, query, where, getDocs, deleteDoc } from 'https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore.js';
+    import { saveStartingWeight, parseWeightInputs } from './presc.js';
 
-    // Firebase configuration - loaded from generated config file
-    const firebaseConfig = window.firebaseConfig;
-    if (!firebaseConfig || !firebaseConfig.projectId) {
-      throw new Error('Firebase config not loaded. Ensure firebase-config.js is present.');
-    }
+    const weightUnit  = document.getElementById('weight-unit');
+    const userSelect  = document.getElementById('user-select');
+    const resultContainer = document.getElementById('result');
+    const resultText  = document.getElementById('result-text');
 
-    // Initialize Firebase
-    const app = initializeApp(firebaseConfig);
-    const db = getFirestore(app);
-
-    const weightUnit = document.getElementById('weight-unit');
-    const userSelect = document.getElementById('user-select');
+    /* ── Unit‑field toggling ─────────────────────────── */
 
     function toggleUnitFields(unit) {
-      const stlb = document.getElementById('start-stlb');
-      const lb = document.getElementById('start-lb');
-      const kg = document.getElementById('start-kg');
-
-      stlb.hidden = unit !== 'st-lb';
-      lb.hidden = unit !== 'lb';
-      kg.hidden = unit !== 'kg';
+      document.getElementById('start-stlb').hidden = unit !== 'st-lb';
+      document.getElementById('start-lb').hidden   = unit !== 'lb';
+      document.getElementById('start-kg').hidden   = unit !== 'kg';
     }
 
     function clearFields(unit) {
-      if (unit !== 'st-lb') {
-        document.getElementById('start-stones').value = '';
-        document.getElementById('start-pounds').value = '';
-      }
-      if (unit !== 'lb') {
-        document.getElementById('start-pounds-only').value = '';
-      }
-      if (unit !== 'kg') {
-        document.getElementById('start-kilograms').value = '';
-      }
-    }
-
-    function parseWeight() {
-      const unit = weightUnit.value;
-      if (unit === 'st-lb') {
-        const stones = parseFloat(document.getElementById('start-stones').value) || 0;
-        const pounds = parseFloat(document.getElementById('start-pounds').value) || 0;
-        return stones * 6.35029 + pounds * 0.45359237;
-      }
-      if (unit === 'lb') {
-        return (parseFloat(document.getElementById('start-pounds-only').value) || 0) * 0.45359237;
-      }
-      return parseFloat(document.getElementById('start-kilograms').value) || 0;
+      if (unit !== 'st-lb') { document.getElementById('start-stones').value = ''; document.getElementById('start-pounds').value = ''; }
+      if (unit !== 'lb')    { document.getElementById('start-pounds-only').value = ''; }
+      if (unit !== 'kg')    { document.getElementById('start-kilograms').value = ''; }
     }
 
     toggleUnitFields(weightUnit.value || 'st-lb');
-    
     weightUnit.addEventListener('change', () => {
-      if (weightUnit.value) {
-        clearFields(weightUnit.value);
-        toggleUnitFields(weightUnit.value);
-      }
+      clearFields(weightUnit.value);
+      toggleUnitFields(weightUnit.value);
     });
+
+    /* ── Save button ─────────────────────────────────── */
 
     document.getElementById('save-btn').addEventListener('click', async () => {
       const user = userSelect.value;
-      const unit = weightUnit.value;
-      const startKg = parseWeight();
-      const resultContainer = document.getElementById('result');
-      const resultText = document.getElementById('result-text');
+      if (!user) { resultContainer.hidden = false; resultText.textContent = 'Please select a user.'; resultText.className = 'result-value'; return; }
+      if (!weightUnit.value) { resultContainer.hidden = false; resultText.textContent = 'Please select weight units.'; resultText.className = 'result-value'; return; }
 
-      if (!user) {
-        resultContainer.hidden = false;
-        resultText.textContent = 'Please select a user.';
-        resultText.className = 'result-value';
-        return;
-      }
-
-      if (!unit) {
-        resultContainer.hidden = false;
-        resultText.textContent = 'Please select weight units.';
-        resultText.className = 'result-value';
-        return;
-      }
-
-      if (!startKg || startKg <= 0) {
-        resultContainer.hidden = false;
-        resultText.textContent = 'Enter a valid starting weight.';
-        resultText.className = 'result-value';
-        return;
-      }
+      const startKg = parseWeightInputs(weightUnit.value, {
+        stones: 'start-stones', pounds: 'start-pounds',
+        poundsOnly: 'start-pounds-only', kg: 'start-kilograms'
+      });
+      if (!startKg || startKg <= 0) { resultContainer.hidden = false; resultText.textContent = 'Enter a valid starting weight.'; resultText.className = 'result-value'; return; }
 
       try {
-        // Check if user already has a starting weight, delete it
-        const q = query(collection(db, 'startingWeight'), where('user', '==', user));
-        const querySnapshot = await getDocs(q);
-        for (const doc of querySnapshot.docs) {
-          await deleteDoc(doc.ref);
-        }
-
-        // Save new starting weight
-        await addDoc(collection(db, 'startingWeight'), {
-          user: user,
-          weight: startKg,
-          unit: weightUnit.value,
-          date: new Date().toISOString()
-        });
-
+        await saveStartingWeight(user, startKg, weightUnit.value);
         resultContainer.hidden = false;
         resultText.textContent = '✓ Starting weight saved!';
         resultText.className = 'result-value lost';


### PR DESCRIPTION
- Create weight/presc.js shared module (Firebase init, chart rendering, weekly competition logic, unit conversion)
- Rewrite index.html, chart.html, setup.html to import from presc.js (removes ~250 lines of duplication)
- chart.html now respects privacy (no actual weights exposed)
- Add cross-navigation links between all three pages
- Remove unused window.firebaseImports script tag
- Add .nojekyll to prevent Jekyll stripping firebase-config.js on GitHub Pages