### PR TITLE
dhondt: mobile viewport, IND cap, effective votes, copy clarity

### DIFF
--- a/dhondt/index.html
+++ b/dhondt/index.html
@@ -13,7 +13,7 @@
   <div id="rotate-prompt" class="rotate-prompt" aria-live="polite">
     <div class="rotate-inner">
       <span class="rotate-icon">🔄</span>
-      <p>Please rotate your device to <strong>landscape</strong> mode to use this simulator.</p>
+      <p>Rotate to <strong>landscape</strong> mode to use this simulator.</p>
     </div>
   </div>
 
@@ -79,7 +79,7 @@
           </div>
 
           <div class="panel-body">
-            <p class="instructions">Enter each party's expected vote share (%), then set turnout.</p>
+            <p class="instructions">Enter each party's vote share (%) and set the turnout. For Independents, also set the number of candidates standing — this caps how many seats they can win.</p>
             <div class="party-inputs-grid" id="party-inputs" role="group" aria-label="Party vote percentages">
               <!-- Rendered by JS -->
             </div>
@@ -112,7 +112,7 @@
           </table>
         </div>
         <div class="calc-footer">
-          <button class="btn btn-primary" id="btn-to-ballot" style="display:none">Proceed to Ballot Boxes →</button>
+          <button class="btn btn-primary" id="btn-to-ballot" style="display:none">Continue to Ballot Count →</button>
         </div>
       </div>
     </section>

--- a/dhondt/script.js
+++ b/dhondt/script.js
@@ -14,6 +14,7 @@ const PARTIES = [
   { name: 'Reform UK',         abbr: 'REF', color: '#12B6CF', text: '#fff' },
 ];
 
+const IND_IDX            = PARTIES.findIndex(p => p.abbr === 'IND');
 const NUM_SEATS          = 6;
 const ELECTORATE_MIN     = 122883;
 const ELECTORATE_MAX     = 152545;
@@ -28,6 +29,7 @@ const state = {
   dhondtSteps:    [],
   stepIndex:      0,
   seatHistory:    [],   // party index for each seat, in order
+  indCandidates:  2,    // max seats Independents can win
 };
 
 // ── Utilities ────────────────────────────────────────────
@@ -57,6 +59,7 @@ function initInputPhase() {
   PARTIES.forEach((party, i) => {
     const card = document.createElement('div');
     card.className = 'party-input-card';
+    const isIND = i === IND_IDX;
     card.innerHTML = `
       <div class="party-input-label">
         <div class="party-dot" style="background:${party.color}"></div>
@@ -74,11 +77,23 @@ function initInputPhase() {
              min="0" max="100" step="1" value="0"
              style="accent-color:${party.color}"
              aria-label="${party.name} vote percentage slider">
+      ${isIND ? `
+      <div class="ind-cand-row">
+        <label class="ind-cand-label" for="ind-candidates">Candidates:</label>
+        <input type="number" id="ind-candidates" class="ind-cand-input"
+               min="0" max="${NUM_SEATS}" step="1" value="${state.indCandidates}"
+               aria-label="Number of independent candidates standing">
+      </div>` : ''}
     `;
     grid.appendChild(card);
   });
 
   grid.addEventListener('input', e => {
+    if (e.target.id === 'ind-candidates') {
+      state.indCandidates = Math.max(0, Math.min(NUM_SEATS,
+        Number.parseInt(e.target.value, 10) || 0));
+      return;
+    }
     const isSlider = e.target.classList.contains('party-slider');
     const isNumber = e.target.classList.contains('party-number-input');
     if (!isSlider && !isNumber) return;
@@ -133,6 +148,9 @@ function resetInputs() {
   document.getElementById('turnout-slider').value = 60;
   document.getElementById('turnout-display').textContent = '60%';
   state.turnout = 60;
+  state.indCandidates = 2;
+  const indCandEl = document.getElementById('ind-candidates');
+  if (indCandEl) indCandEl.value = 2;
   clearInputError();
   updateTotal();
 }
@@ -159,12 +177,14 @@ function clearInputError() {
 function confirmInputs() {
   const total = state.percentages.reduce((a, b) => a + b, 0);
   if (total === 0) {
-    showInputError('Please enter vote percentages for at least one party before confirming.');
+    showInputError('Enter vote percentages for at least one party.');
     return;
   }
   clearInputError();
-  state.electorate = rand(ELECTORATE_MIN, ELECTORATE_MAX);
-  state.turnout    = +document.getElementById('turnout-slider').value;
+  state.electorate    = rand(ELECTORATE_MIN, ELECTORATE_MAX);
+  state.turnout       = +document.getElementById('turnout-slider').value;
+  state.indCandidates = Math.max(0, Math.min(NUM_SEATS,
+    Number.parseInt(document.getElementById('ind-candidates')?.value ?? '2', 10) || 0));
   state.totalVotes = Math.round(state.electorate * (state.turnout / 100));
   state.partyVotes = state.percentages.map(pct =>
     Math.round(state.totalVotes * (pct / 100))
@@ -257,7 +277,7 @@ async function initBallotPhase() {
   document.getElementById('btn-sort-boxes').onclick = async () => {
     document.getElementById('btn-sort-boxes').style.display = 'none';
     await sortBallotBoxes();
-    heading.textContent = 'Votes sorted — ready for seat allocation!';
+    heading.textContent = 'Votes sorted — ready to allocate seats!';
     await sleep(400);
     const dhondtBtn = document.getElementById('btn-to-dhondt');
     dhondtBtn.style.display = 'inline-block';
@@ -413,11 +433,14 @@ function computeDhondtSteps() {
   const seatsWon = Array(PARTIES.length).fill(0);
   const history  = [];
 
-  // Helper: find index of party with highest adjusted votes
+  // Helper: find index of eligible party with highest adjusted votes
   function leader(divs) {
-    let best = 0;
-    for (let i = 1; i < PARTIES.length; i++) {
-      if (state.partyVotes[i] / divs[i] > state.partyVotes[best] / divs[best]) {
+    const partyMaxSeats = PARTIES.map((_, i) => i === IND_IDX ? state.indCandidates : NUM_SEATS);
+    let best = -1;
+    for (let i = 0; i < PARTIES.length; i++) {
+      if (state.partyVotes[i] === 0) continue;
+      if (seatsWon[i] >= partyMaxSeats[i]) continue;
+      if (best === -1 || state.partyVotes[i] / divs[i] > state.partyVotes[best] / divs[best]) {
         best = i;
       }
     }
@@ -431,19 +454,20 @@ function computeDhondtSteps() {
     adjusted:    state.partyVotes.map((v, i) => Math.round(v / divisors[i])),
     seatsWon:    [...seatsWon],
     history:     [],
-    message:     "The <strong>D'Hondt method</strong> allocates seats by repeatedly dividing each party's votes by a divisor. Every party's divisor starts at <strong>1</strong>, which leaves their vote totals unchanged. The party with the highest total at each stage receives the next seat.",
+    message:     "In the <strong>D'Hondt method</strong>, each party's votes are divided by a divisor — starting at <strong>1</strong>. The party with the highest adjusted total wins the next seat. When a party wins a seat, their divisor increases by 1, reducing their adjusted total for future rounds.",
     btnText:     'Allocate Seat 1 →',
     highlight:   -1,
   });
 
   for (let seat = 1; seat <= NUM_SEATS; seat++) {
-    const win       = leader(divisors);
+    const win = leader(divisors);
+    if (win === -1) break;  // no eligible parties remain
     const prevWin   = history.length ? history[history.length - 1] : -1;
     const adjVotes  = state.partyVotes.map((v, i) => Math.round(v / divisors[i]));
 
     let leadMsg;
     if (seat === 1) {
-      leadMsg = `<strong>${PARTIES[win].name}</strong> has the highest vote total (${fmt(adjVotes[win])}) — they receive <strong>Seat ${seat}</strong>! 🎉`;
+      leadMsg = `<strong>${PARTIES[win].name}</strong> has the highest adjusted total (${fmt(adjVotes[win])}) — they receive <strong>Seat ${seat}</strong>! 🎉`;
     } else if (win === prevWin) {
       leadMsg = `<strong>${PARTIES[win].name}</strong> is <em>still</em> in the lead with an adjusted total of <strong>${fmt(adjVotes[win])}</strong> — they receive <strong>Seat ${seat}</strong>! 🎉`;
     } else {
@@ -643,16 +667,24 @@ function renderDhondtBoxes(divisors, adjusted, history, highlightIdx) {
     box.setAttribute('role', 'listitem');
     box.setAttribute('aria-label', `${party.name}: ${fmt(adjusted[pi])} adjusted votes, divisor ${divisors[pi]}`);
 
+    const isCapped = pi === IND_IDX && seatsWon >= state.indCandidates;
     if (pi === highlightIdx) box.classList.add('highlight');
+    if (isCapped) box.classList.add('dim');
+
+    const seatWord = state.indCandidates === 1 ? 'seat' : 'seats';
+    const capBadge = (pi === IND_IDX && state.indCandidates < NUM_SEATS)
+      ? `<div class="bbox-cap">Cap: ${state.indCandidates} ${seatWord}</div>`
+      : '';
 
     box.innerHTML = `
       <div class="bbox-rank">#${rank + 1}</div>
       <div class="bbox-logo" style="background:${party.color};color:${party.text}">${party.abbr}</div>
       <div class="bbox-name">${party.name}</div>
+      ${capBadge}
       <div class="bbox-votes">${fmt(state.partyVotes[pi])}</div>
       <div class="bbox-div-label">÷ divisor</div>
       <div class="bbox-divisor" id="div-label-${pi}">${divisors[pi]}</div>
-      <div class="bbox-div-label">= adjusted</div>
+      <div class="bbox-div-label">= effective</div>
       <div class="bbox-adjusted">${fmt(adjusted[pi])}</div>
       ${seatsWon > 0 ? `<div class="bbox-seats-icons">${'🟡'.repeat(seatsWon)}</div>` : ''}
     `;

--- a/dhondt/style.css
+++ b/dhondt/style.css
@@ -17,6 +17,7 @@
   --primary:     #005b54;
   --primary-h:   #00796e;
   --danger:      #e04040;
+  --effective:   #60d0f0;   /* adjusted / effective vote count */
 
   /* Party colours */
   --con: #0087DC;
@@ -63,7 +64,7 @@ html, body {
 /* ── App shell ──────────────────────────────────────────── */
 #app {
   position: relative;
-  width: 100%; height: 100vh;
+  width: 100%; height: 100vh; height: 100dvh;
 }
 
 /* ── Phases ─────────────────────────────────────────────── */
@@ -134,7 +135,7 @@ html, body {
   -webkit-backdrop-filter: blur(12px);
   width: 100%; max-width: 740px;
   /* Never taller than the viewport */
-  max-height: 92vh;
+  max-height: 92vh; max-height: 92dvh;
   display: flex; flex-direction: column;
   padding: 8px 12px;
   box-shadow: var(--shadow);
@@ -261,6 +262,30 @@ html, body {
   flex-shrink: 0;
 }
 
+/* Independents candidate count row (within party card) */
+.ind-cand-row {
+  display: flex; align-items: center; justify-content: space-between;
+  margin-top: 4px; padding-top: 4px;
+  border-top: 1px solid rgba(107, 114, 128, 0.3);
+}
+.ind-cand-label {
+  font-size: 9px; color: var(--muted); white-space: nowrap;
+}
+.ind-cand-input {
+  font-size: 13px; font-weight: 700; color: var(--ind);
+  background: transparent; border: none;
+  border-bottom: 1px solid rgba(107, 114, 128, 0.4);
+  width: 28px; text-align: center; outline: none;
+  -moz-appearance: textfield;
+}
+.ind-cand-input::-webkit-inner-spin-button,
+.ind-cand-input::-webkit-outer-spin-button { -webkit-appearance: none; }
+.ind-cand-input:focus {
+  border-bottom-color: var(--ind);
+  background: rgba(107, 114, 128, 0.12);
+  border-radius: 2px 2px 0 0;
+}
+
 /* ════════════════════════════════════════════════════════════
    PHASE 2 – CALCULATION
    ════════════════════════════════════════════════════════════ */
@@ -273,7 +298,7 @@ html, body {
   padding: 10px 16px;
   display: flex; flex-direction: column;
   /* Fill but never overflow the viewport */
-  max-height: 100vh; overflow: hidden;
+  max-height: 100vh; max-height: 100dvh; overflow: hidden;
 }
 .calc-wrapper h2 {
   font-size: 16px; color: var(--gold);
@@ -452,9 +477,18 @@ html, body {
   color: var(--gold); text-align: center; line-height: 1;
 }
 .bbox-adjusted  {
-  font-size: 10px; color: var(--muted); text-align: center; line-height: 1;
+  font-size: 12px; font-weight: 800;
+  color: var(--effective); text-align: center; line-height: 1;
 }
 .bbox-div-label { font-size: 8px; color: var(--muted); text-align: center; }
+.bbox-cap {
+  font-size: 8px; color: #6B7280;
+  background: rgba(107, 114, 128, 0.18);
+  border-radius: 3px; padding: 1px 5px;
+  text-align: center; line-height: 1.4;
+}
+/* In D'Hondt phase the boxes are smaller — match votes font-size */
+.dhondt-boxes-row .bbox-adjusted { font-size: 11px; }
 
 /* Bottom: message + button */
 .dhondt-bottom {


### PR DESCRIPTION
- Use 100dvh/92dvh alongside 100vh/92vh so dynamic browser chrome (URL bar, nav) on Google Pixel doesn't clip the layout
- Add Independents candidate count input; caps max seats IND can win via D'Hondt leader() eligibility check; shows dim + badge when capped
- Promote bbox-adjusted to same size/weight as bbox-votes, coloured cyan (--effective) to distinguish from total votes (gold)
- Rename '= adjusted' label to '= effective' throughout
- Tighten all user-facing strings for clarity and brevity